### PR TITLE
Wait for u-boot to complete to allow WiFi to initialize

### DIFF
--- a/arduino/StandardFirmataYun/StandardFirmataYun.ino
+++ b/arduino/StandardFirmataYun/StandardFirmataYun.ino
@@ -594,7 +594,6 @@ void setup()
      while (Serial1.available() > 0) {
         Serial1.read();
      }
-    
     delay(1000);
   } while (Serial1.available() > 0);
   


### PR DESCRIPTION
I modified setup() to wait for u-boot to complete. Without this change WiFi would initialize and I could not connect to the Yun.
